### PR TITLE
Using tips will spend points

### DIFF
--- a/gem_manager.cpp
+++ b/gem_manager.cpp
@@ -37,6 +37,7 @@ void GemManager::reset()
 	score = 0;
 	// do not spawn a bomb too soon? change to a greater value
 	latestBomb = 0;
+	usedTip = false;
 	setState(State::WAITING);
 }
 
@@ -88,6 +89,7 @@ void GemManager::update()
 		if (m > 0) {
 			setState(State::MOVING);
 			score += m;
+			usedTip = false;
 		} else if (arrange()) {
 			setState(State::MOVING);
 		}
@@ -103,6 +105,7 @@ void GemManager::update()
 			if (state == State::SWAPPING) {
 				int m = match();
 				score += m;
+				usedTip = false;
 				if (m == 0) {
 					auto& gem = gems[sel1];
 					auto& other = gems[sel2];
@@ -258,10 +261,15 @@ bool GemManager::checkMatch3(Gem* gem1, Gem* gem2, Gem* gem3, bool show)
 	//if (gem1->getColor() == gem2->getColor() && gem1->getColor() ==  gem3->getColor()) {
 	// check only gem1 and 3 as gem2 was already matched with gem1
 	if (gem1->getColor() == gem3->getColor()) {
-		if (show) {
+		if (show && (score >= pointsPerTip || usedTip)) {
 			gem1->setPossibleMatch(true);
 			gem2->setPossibleMatch(true);
 			gem3->setPossibleMatch(true);
+			if (!usedTip) {
+				score -= pointsPerTip;
+				usedTip = true;
+			}
+
 		}
 		return true;
 	}

--- a/gem_manager.hpp
+++ b/gem_manager.hpp
@@ -22,6 +22,7 @@ public:
 	static constexpr int rows = 8;
 	static constexpr int cols = 8;
 	static constexpr int pointsPerBomb = 50;
+	static constexpr int pointsPerTip = 50;
 
 	int getScore() const { return score; }
 
@@ -48,5 +49,5 @@ private:
 	State        state;
 	int          score;
 	int          latestBomb;
-
+	bool	     usedTip;
 };


### PR DESCRIPTION
Implementation for #2 - Use points to buy tips.

The user will only be charged once to buy a tip (50 points) and won't be charged again until they complete a match. If they don't have enough points, no points are deducted and a tip is not shown.